### PR TITLE
Essential fixes for OSX 10.11

### DIFF
--- a/README
+++ b/README
@@ -36,8 +36,6 @@ for it by themselves.
 
 1) Call `bootstrap.sh` to install jhbuild and set up dummy `$HOME` as base.
 2) Call `build.sh` to download and build all the dependencies.
-   I get an error with openssl, but it still installs correctly.
-   Simply choose `[2] ignore error` and move forward.
 3) Call `bundle.sh` to create the finished bundles for gPodder in
    `_build`.
 

--- a/README
+++ b/README
@@ -5,7 +5,8 @@ OS X Bundle Build Scripts
 This is a collection of files required to build gPodder.app :
 gPodder as a native GTK+ Quartz application for Mac OS X 10.6 and 10.7
 
-I used them to build on a 10.6 X86_64 machine.
+The scripts are verified on an OSX 10.11.4 (15E65) `x86_64` machine with
+Xcode 7.3 (7D175).
 
 **Note:**
     In case you want just want to run gPodder from source you can ignore
@@ -32,7 +33,7 @@ like homebrew or macports aren't in your `$PATH`. To be extra sure, move
 `/opt/local` away, because some configure scripts are clever enough to look
 for it by themselves.
 
-(Tested on OS X 10.6.8)
+(Tested on OS X 10.11.4)
 
 1) Call `bootstrap.sh` to install jhbuild and set up dummy `$HOME` as base.
 2) Call `build.sh` to download and build all the dependencies.

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
 
+set -e
+
 source env.sh
 
-jhbuild build autoconf --nodeps
 jhbuild bootstrap
 jhbuild build python
 jhbuild build meta-gtk-osx-bootstrap

--- a/bundle.sh
+++ b/bundle.sh
@@ -53,6 +53,7 @@ cp -R "$JHBUILD_PREFIX"/share/strings/*.lproj "$APP_PREFIX"
 # check for dynamic linking consistency : nothing should reference gtk/inst
 find "$APP_PREFIX" -name '*.so' -and -print -and  -exec sh -c 'otool -L $1 | grep /gtk/inst' '{}' '{}' ';'
 
+cat "$JHBUILD_PREFIX/_jhbuild/info/"* > "$JHBUILD_PREFIX/_jhbuild/packagedb.xml"
 # list the provenance of every file in the bundle
 $mydir/misc/provenance.pl "$JHBUILD_PREFIX" "$APP" > "$QL_OSXBUNDLE_BUNDLE_DEST"/gPodder.contents
 

--- a/bundle.sh
+++ b/bundle.sh
@@ -50,6 +50,10 @@ mv gpodder.ui.tmp "$APP_PREFIX"/share/gpodder/ui/gtk/gpodder.ui
 # localization of Quit and other menu items controlled by gtk-mac-integration
 cp -R "$JHBUILD_PREFIX"/share/strings/*.lproj "$APP_PREFIX"
 
+# fixes this error at startup:
+# gPodder.app/Contents/Resources/lib/python2.7/site-packages/gpodder/gtkui/draw.py:300: GtkWarning: Cannot open pixbuf loader module file 'gPodder.app/Contents/Resources/etc/gtk-2.0/gdk-pixbuf.loaders': No such file or directory
+"$JHBUILD_PREFIX/bin/gdk-pixbuf-query-loaders" > "$APP_PREFIX"/etc/gtk-2.0/gdk-pixbuf.loaders
+
 # check for dynamic linking consistency : nothing should reference gtk/inst
 find "$APP_PREFIX" -name '*.so' -and -print -and  -exec sh -c 'otool -L $1 | grep /gtk/inst' '{}' '{}' ';'
 

--- a/misc/gtk-osx-jhbuildrc
+++ b/misc/gtk-osx-jhbuildrc
@@ -368,10 +368,11 @@ def setup_sdk(target, sdk_version, architectures=[_default_arch]):
     # El Capitan needs bash to work around SIP. If you're using a
     # common bootstrap directory (e.g. $HOME/.local) then override
     # CONFIG_SHELL in .jhbuildrc-custom after calling setup_sdk().
+    config_shell = os.path.join(prefix, 'bin', 'bash')
     if _osx_version < 11.0:
         skip.append('bash')
-    elif not 'bootstrap' in modules:
-        os.environ['CONFIG_SHELL'] = os.path.join(prefix, 'bin', 'bash')
+    elif os.path.exists(config_shell):
+        os.environ['CONFIG_SHELL'] = config_shell
 
     # gettext-fw rebuilds gettext with an in-tree libiconv to get
     # around the Apple-provided one not defining _libiconv_init for
@@ -547,6 +548,7 @@ if os.path.exists(_userrc):
 # builds, for example.
 #
 _build = os.environ.get('JHB', _gtk_osx_default_build)
+disable_Werror = False
 
 ###### Everything Below Uses (and Overrides) customizations! #######
 

--- a/misc/jhbuildrc-custom
+++ b/misc/jhbuildrc-custom
@@ -6,7 +6,7 @@ import os
 checkoutroot = os.path.expanduser("~/jhbuild_checkoutroot")
 prefix = os.path.expanduser("~/jhbuild_prefix")
 modulesets_dir = os.environ["QL_OSXBUNDLE_MODULESETS_DIR"]
-moduleset = ["bootstrap", "quodlibet"]
+moduleset = "gpodder"
 modules = []
 
 disable_Werror = False

--- a/misc/provenance.pl
+++ b/misc/provenance.pl
@@ -38,7 +38,7 @@ foreach my $pkg (@manifest_files) {
 	open(my $MANIFEST, "<", $manifest) || die "can't open $manifest for reading: $!\n";
 	while(my $l = <$MANIFEST>){
 		chomp $l;
-		push(@{$pkg_by_f{$l}}, $pkg);
+		push(@{$pkg_by_f{"/$l"}}, $pkg);
 	}
 }
 
@@ -52,10 +52,9 @@ foreach my $file (@files) {
 	next if -d $file;
 	my $short = $file;
 	$short =~ s/$gPodderResources//;
-	my $inst = "$gtk_inst$short";
 	my @pkgs;
-	if($pkg_by_f{$inst}){
-		@pkgs = @{$pkg_by_f{$inst}};
+	if($pkg_by_f{$short}){
+		@pkgs = @{$pkg_by_f{$short}};
 	} else {
 		@pkgs = ();
 	}

--- a/modulesets/bootstrap.modules
+++ b/modulesets/bootstrap.modules
@@ -21,11 +21,17 @@
   <repository type="tarball" name="intltool"
               href="http://launchpad.net/intltool/trunk/"/>
 
-  <autotools id="make">
+  <autotools id="make" bootstrap="true">
     <branch repo="ftp.gnu.org" module="make/make-3.82.tar.gz" version="3.82"/>
   </autotools>
 
-  <autotools id='bash' autogen-sh="configure">
+  <autotools id='readline' autogen-sh="configure">
+    <branch repo="ftp.gnu.org" module="readline/readline-6.3.tar.gz"
+      version="6.3">
+    </branch>
+  </autotools>
+
+  <autotools id='bash' autogen-sh="configure"  autogenargs="--with-installed-readline">
     <branch repo="ftp.gnu.org" module="bash/bash-4.3.30.tar.gz"
             version="4.3.30"/>
     <dependencies>
@@ -33,7 +39,7 @@
     </dependencies>
   </autotools>
 
-  <autotools id="xz" autogen-sh="configure">
+  <autotools id="xz" autogen-sh="configure" bootstrap="true">
     <branch repo="tukaani.org" module="xz/xz-5.2.1.tar.bz2" version="5.2.1"/>
   </autotools>
 
@@ -67,57 +73,76 @@
   <autotools id="cmake" autogen-sh="bootstrap"
              autogen-template="%(srcdir)s/%(autogen-sh)s --prefix=%(prefix)s">
     <branch repo="cmake" module="v3.2/cmake-3.2.1.tar.gz" version="3.2.1">
-      <patch file="http://git.gnome.org/browse/gtk-osx/plain/patches/cmake-libnetwork.patch" strip="1"/>
+      <patch file="https://git.gnome.org/browse/gtk-osx/plain/patches/cmake-libnetwork.patch" strip="1"/>
     </branch>
   </autotools>
 
-  <autotools id="m4" autogen-sh="configure">
+  <autotools id="m4" autogen-sh="configure" bootstrap="true">
     <branch repo="ftp.gnu.org"
             module="m4/m4-1.4.17.tar.xz" version="1.4.17"/>
   </autotools>
 
-  <autotools id="autoconf" autogen-sh="configure">
+  <autotools id="autoconf" autogen-sh="configure" bootstrap="true">
     <branch repo="ftp.gnu.org"
             module="autoconf/autoconf-2.69.tar.xz" version="2.69"/>
     <dependencies>
+      <dep package="xz"/>
       <dep package="m4"/>
     </dependencies>
   </autotools>
 
-  <autotools id="libtool" autogen-sh="configure">
+  <autotools id="libtool" autogen-sh="configure" bootstrap="true">
     <branch repo="ftp.gnu.org"
             module="libtool/libtool-2.4.6.tar.gz" version="2.4.6"/>
   </autotools>
 
-  <autotools id="automake-1.10" autogen-sh="configure">
+  <autotools id="automake-1.10" autogen-sh="configure" bootstrap="true">
     <branch repo="ftp.gnu.org"
             module="automake/automake-1.10.3.tar.bz2" version="1.10.3"
             size="957505" md5sum="b8e67fb458da396bc35555af7ef2b49f" />
+    <dependencies>
+      <dep package="autoconf"/>
+    </dependencies>
   </autotools>
 
-  <autotools id="automake-1.11" autogen-sh="configure">
+  <autotools id="automake-1.11" autogen-sh="configure" bootstrap="true">
     <branch repo="ftp.gnu.org"
             module="automake/automake-1.11.6.tar.xz" version="1.11.6"/>
+    <dependencies>
+      <dep package="autoconf"/>
+    </dependencies>
   </autotools>
 
-  <autotools id="automake-1.12" autogen-sh="configure">
+  <autotools id="automake-1.12" autogen-sh="configure" bootstrap="true">
     <branch repo="ftp.gnu.org"
             module="automake/automake-1.12.6.tar.xz" version="1.12.6"/>
+    <dependencies>
+      <dep package="autoconf"/>
+    </dependencies>
   </autotools>
 
-  <autotools id="automake-1.13" autogen-sh="configure">
+  <autotools id="automake-1.13" autogen-sh="configure" bootstrap="true">
     <branch repo="ftp.gnu.org"
             module="automake/automake-1.13.4.tar.xz" version="1.13.4"/>
+    <dependencies>
+      <dep package="autoconf"/>
+    </dependencies>
   </autotools>
 
-  <autotools id="automake-1.14" autogen-sh="configure">
+  <autotools id="automake-1.14" autogen-sh="configure" bootstrap="true">
     <branch repo="ftp.gnu.org" version="1.14.1"
             module="automake/automake-1.14.1.tar.xz"/>
+    <dependencies>
+      <dep package="autoconf"/>
+    </dependencies>
   </autotools>
 
-  <autotools id="automake" autogen-sh="configure">
+  <autotools id="automake" autogen-sh="configure" bootstrap="true">
     <branch repo="ftp.gnu.org" version="1.15"
             module="automake/automake-1.15.tar.gz"/>
+    <dependencies>
+      <dep package="autoconf"/>
+    </dependencies>
   </autotools>
 
   <autotools id="pkg-config" autogen-sh="configure"
@@ -202,6 +227,7 @@
       <dep package="make"/>     <!-- Needed for Tiger, skipped otherwise -->
       <dep package="subversion"/>   <!-- Needed for Tiger, skipped otherwise -->
       <dep package="gettext-tools" /> <!-- Needed for 64-bit -->
+      <dep package="readline" />
       <dep package="bash" />  <!-- Needed for El Cap and later to work around SIP. -->
       <dep package="cmake"/>
       <dep package="m4"/>	<!-- Can be skipped for Leopard and later -->

--- a/modulesets/gtk-osx-network.modules
+++ b/modulesets/gtk-osx-network.modules
@@ -45,7 +45,9 @@
   <autotools id="openssl" autogen-sh="Configure" autogenargs="shared"
              autogen-template="%(srcdir)s/%(autogen-sh)s --prefix=%(prefix)s --openssldir=%(prefix)s/etc/ssl %(autogenargs)s"
              makeinstallargs="install_sw" supports-non-srcdir-builds="no" supports-parallel-builds="no">
-    <branch module="openssl-0.9.8zg.tar.gz" version="0.9.8zg" repo="openssl"/>
+    <branch module="openssl-0.9.8zg.tar.gz" version="0.9.8zg" repo="openssl">
+      <patch file="patches/openssl-respect-destdir.patch" />
+    </branch>
   </autotools>
 
   <!-- Rudely demands TeX to build documentation -->

--- a/modulesets/gtk-osx-python.modules
+++ b/modulesets/gtk-osx-python.modules
@@ -72,7 +72,9 @@
 	     autogen-sh="configure" supports-non-srcdir-builds="no">
     <branch repo="python"
 	    module="2.7.8/Python-2.7.8.tar.xz" version="2.7.8">
-      <patch file="http://git.gnome.org/browse/gtk-osx/plain/patches/python-2.7.8-test_grammar.py-typo.patch" strip="1"/>
+      <patch file="https://git.gnome.org/browse/gtk-osx/plain/patches/python2-test_grammar.py-typo.patch" strip="1"/>
+      <patch file="https://git.gnome.org/browse/gtk-osx/plain/patches/python2-xcode-stubs.patch" strip="1"/>
+      <patch file="https://git.gnome.org/browse/gtk-osx/plain/patches/python2-linkflags.patch" strip="1"/>"/>
     </branch>
     <dependencies>
       <dep package="gettext-runtime"/>

--- a/modulesets/gtk-osx.modules
+++ b/modulesets/gtk-osx.modules
@@ -183,7 +183,7 @@
             hash="sha256:b2c6441e98bc5232e5f9bba6965075dcf580a8726398f7374d39f90b88ed4656">
       <!--patch file="http://git.gnome.org/browse/gtk-osx/plain/patches/0004-Bug-571582-GtkSelection-implementation-for-quartz.patch" strip="1"/-->
       <patch file="http://git.gnome.org/browse/gtk-osx/plain/patches/0008-Implement-GtkDragSourceOwner-pasteboardChangedOwner.patch" strip="1"/>
-      <patch file="http://git.gnome.org/browse/gtk-osx/plain/patches/0006-Bug-658722-Drag-and-Drop-sometimes-stops-working.patch" strip="1"/>
+      <patch file="https://git.gnome.org/browse/gtk-osx/plain/patches/0006-Bug-658722-Drag-and-Drop-sometimes-stops-working.patch?id=6c455cb011c29784c82335031deea78cf7aec52b" strip="1"/>
 <patch file="http://git.gnome.org/browse/gtk-osx/plain/patches/gtk+-2-m4-creation.patch" strip="1"/>
       <patch file="http://git.gnome.org/browse/gtk-osx/plain/patches/0001-Bug-707945-GTK2-Quartz-typeahead-find-in-GtkTreeView.patch" strip="1"/>
    </branch>

--- a/modulesets/patches/openssl-respect-destdir.patch
+++ b/modulesets/patches/openssl-respect-destdir.patch
@@ -1,0 +1,11 @@
+--- Configure	2016-04-27 22:53:25.000000000 -0700
++++ Configure	2016-04-27 22:53:47.000000000 -0700
+@@ -595,7 +595,7 @@
+ my $libdir="";
+ my $openssldir="";
+ my $exe_ext="";
+-my $install_prefix= "$ENV{'INSTALL_PREFIX'}";
++my $install_prefix='$(DESTDIR)';
+ my $cross_compile_prefix="";
+ my $fipslibdir="/usr/local/ssl/fips-1.0/lib/";
+ my $nofipscanistercheck=0;


### PR DESCRIPTION
This is the first PR with essential changes I had to do to build on OSX 10.11; fixes #3. There will be enhancement PRs.

* `jhbuildrc-custom`: set moduleset to "gpodder";
* Updates the `gtk-osx-jhbuildrc` file to the current upstream version, which fixes an issue with `/bin/bash` on OSX 10.11.
* Updates the `bootstrap.modules` file to the current upstream version, which fixes circular dependency warnings when `bootstrap`ping and sets proper dependencies for `autoconf` -- no need to build it first manually in `build.sh`.
* Allow `openssl` to be installed into `DESTDIR`: `openssl`'s configuration scripts up to version 1.1.0 use the `INSTALL_PREFIX` variable to designate the desired staging directory, instead of the common `DESTDIR`, which `jhbuild` expects (see openssl/openssl@3c65577). So because the files are installed not in the expected directory, `jhbuild` fails with an error. This change adds a patch to fix this behavior in the current `openssl` version.
* Adds python patches to build properly on OSX 10.11.
* `gtk-osx.modules`: Update patch for gtk+. The current patch at the URL can be applied to newer gtk+ versions, but not to the one used here. This commit updates the URL to get the older version. See history here: https://git.gnome.org/browse/gtk-osx/log/patches/0006-Bug-658722-Drag-and-Drop-sometimes-stops-working.patch

@elelay, please verify that these updates work for you, if possible.