### PR TITLE
Scripts enhancements

### DIFF
--- a/README
+++ b/README
@@ -36,8 +36,6 @@ for it by themselves.
 
 1) Call `bootstrap.sh` to install jhbuild and set up dummy `$HOME` as base.
 2) Call `build.sh` to download and build all the dependencies.
-   I get an error with openssl, but it still installs correctly.
-   Simply choose `[2] ignore error` and move forward.
 3) Call `bundle.sh` to create the finished bundles for gPodder in
    `_build`.
 

--- a/README
+++ b/README
@@ -5,7 +5,8 @@ OS X Bundle Build Scripts
 This is a collection of files required to build gPodder.app :
 gPodder as a native GTK+ Quartz application for Mac OS X 10.6 and 10.7
 
-I used them to build on a 10.6 X86_64 machine.
+The scripts are verified on an OSX 10.11.4 (15E65) `x86_64` machine with
+Xcode 7.3 (7D175).
 
 **Note:**
     In case you want just want to run gPodder from source you can ignore
@@ -32,7 +33,7 @@ like homebrew or macports aren't in your `$PATH`. To be extra sure, move
 `/opt/local` away, because some configure scripts are clever enough to look
 for it by themselves.
 
-(Tested on OS X 10.6.8)
+(Tested on OS X 10.11.4)
 
 1) Call `bootstrap.sh` to install jhbuild and set up dummy `$HOME` as base.
 2) Call `build.sh` to download and build all the dependencies.

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -29,10 +29,10 @@ https://developer.apple.com/xcode/downloads/[`Xcode`] and
 https://git-scm.com/download/mac[`git`].
 
 Verify that Xcode and git is installed and in your `$PATH` by invoking `git
---version` and `gcc --version`. Also make sure that other package managers
-like homebrew or macports aren't in your `$PATH`. To be extra sure, move
-`/opt/local` away, because some configure scripts are clever enough to look
-for it by themselves.
+--version` and `gcc --version`. The `env.sh` script resets your `$PATH` to the
+default value (`{,/usr}/{,s}bin`) to make sure non-native programs, installed
+by other package managers like homebrew or macports, are not used (read more
+https://wiki.gnome.org/Projects/GTK+/OSX/Building#line-38[here]).
 
 (Tested on OS X 10.11.4)
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1,17 +1,17 @@
 = OS X Bundle Build Scripts
 
+*Don't Panic*
+
 This is a collection of files required to build gPodder.app :
-gPodder as a native GTK+ Quartz application for Mac OS X 10.6 and 10.7
+gPodder as a native GTK+ Quartz application for Mac OS X 10.6+
 
 The scripts are verified on an OSX 10.11.4 (15E65) `x86_64` machine with
 Xcode 7.3 (7D175).
 
-**Note:**
-    In case you want just want to run gPodder from source you can ignore
-    all this and use the released bundle as a development environment.
-    Download the official bundle, git clone the gPodder repo and do
-    `./gPodder.app/Contents/MacOS/run gpodder.py`.
-
+NOTE: In case you want just want to run gPodder from source you can ignore all
+this and use the released bundle as a development environment.  Download the
+official bundle, git clone the gPodder repo and do
+`./gPodder.app/Contents/MacOS/run gpodder.py`.
 
 Uses https://git.gnome.org/browse/jhbuild/[jhbuild] and the stable module
 set provided by https://git.gnome.org/browse/gtk-osx/[gtk-osx] with a
@@ -41,26 +41,24 @@ https://wiki.gnome.org/Projects/GTK+/OSX/Building#line-38[here]).
 . Call `bundle.sh` to create the finished bundles for gPodder in
    `_build`.
 
-
 == Development
 
 * After `bootstrap.sh` has finished executing `source env.sh` will put you
   in the build environment. After that jhbuild can be used directly.
-* `fetch_modules()` downloads the git master of the gtk-osx module set
+* `fetch_modules.sh` downloads the git master of the gtk-osx module set
   and replaces the modules under "modulessets" and the
   `misc/gtk-osx-jhbuildrc` file. Doing so so should ideally be followed by a
   review of the gPodder module to reduce duplication and a rebuilt to verify
   that everything still works.
 
-
 == Releasing
 
 Releasing on OS X
 
-. see *Creating a Bundle*
+. see *<<Creating a Bundle>>*
 . `./release.sh _build/gPodder.app version_buildnumber`
 . `./release_deps.sh _build/gPodder.app version_buildnumber`
- 
+
 Releasing on Linux by patching deps:
 
 [start=4]
@@ -74,8 +72,6 @@ See https://github.com/elelay/gpodder-osx-bundle
 
 See https://github.com/elelay/gpoder-osx-bundle/wiki/Using for instructions...
 And the official help guide http://gpodder.org/documentation
-
-
 
 == Content Description
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1,6 +1,4 @@
-OS X Bundle Build Scripts
-=========================
-
+= OS X Bundle Build Scripts
 
 This is a collection of files required to build gPodder.app :
 gPodder as a native GTK+ Quartz application for Mac OS X 10.6 and 10.7
@@ -15,7 +13,8 @@ Xcode 7.3 (7D175).
     `./gPodder.app/Contents/MacOS/run gpodder.py`.
 
 
-Uses jhbuild [3] and the stable module set provided by gtk-osx [2] with a
+Uses https://git.gnome.org/browse/jhbuild/[jhbuild] and the stable module
+set provided by https://git.gnome.org/browse/gtk-osx/[gtk-osx] with a
 gPodder specific module set overlay to build all needed dependencies for gPodder.
 Everything will be downloaded/installed into this directory and your
 user directory will not be touched.
@@ -23,9 +22,11 @@ user directory will not be touched.
 Builds upon the great scripts by Christoph Reiter to automate my previously
 tedious description.
 
-# Creating a Bundle
+== Creating a Bundle
 
-Prerequisites: `OS X` 10.6+ and a working `Xcode` [0] and `git` [1]
+Prerequisites: `OS X` 10.6+ and a working
+https://developer.apple.com/xcode/downloads/[`Xcode`] and
+https://git-scm.com/download/mac[`git`].
 
 Verify that Xcode and git is installed and in your `$PATH` by invoking `git
 --version` and `gcc --version`. Also make sure that other package managers
@@ -35,13 +36,13 @@ for it by themselves.
 
 (Tested on OS X 10.11.4)
 
-1) Call `bootstrap.sh` to install jhbuild and set up dummy `$HOME` as base.
-2) Call `build.sh` to download and build all the dependencies.
-3) Call `bundle.sh` to create the finished bundles for gPodder in
+. Call `bootstrap.sh` to install jhbuild and set up dummy `$HOME` as base.
+. Call `build.sh` to download and build all the dependencies.
+. Call `bundle.sh` to create the finished bundles for gPodder in
    `_build`.
 
 
-# Development
+== Development
 
 * After `bootstrap.sh` has finished executing `source env.sh` will put you
   in the build environment. After that jhbuild can be used directly.
@@ -52,35 +53,32 @@ for it by themselves.
   that everything still works.
 
 
-# Releasing
+== Releasing
 
 Releasing on OS X
- 1. see *Creating a Bundle*
- 2. `./release.sh _build/gPodder.app version_buildnumber`
- 3. `./release_deps.sh _build/gPodder.app version_buildnumber`
+
+. see *Creating a Bundle*
+. `./release.sh _build/gPodder.app version_buildnumber`
+. `./release_deps.sh _build/gPodder.app version_buildnumber`
  
 Releasing on Linux by patching deps:
- 4. ./release_on_linux.sh ~/Downloads/gPodder-3.8.4_0.deps.zip /tmp/gpodder master f699341
 
-# Issues
+[start=4]
+. `./release_on_linux.sh ~/Downloads/gPodder-3.8.4_0.deps.zip /tmp/gpodder master f699341`
+
+== Issues
 
 See https://github.com/elelay/gpodder-osx-bundle
 
-# Using gPodder:
+== Using gPodder:
 
 See https://github.com/elelay/gpoder-osx-bundle/wiki/Using for instructions...
 And the official help guide http://gpodder.org/documentation
 
 
 
-# Content Description
+== Content Description
 
 * `modulesets` contains the gtk-osx stable module set and a gpodder module
   which adds new packages replaces existing ones.
 * `misc`: see each file or directory README for a description.
-
-
-| [0] https://developer.apple.com/xcode/downloads/
-| [1] https://git-scm.com/download/mac
-| [2] https://git.gnome.org/browse/gtk-osx/
-| [3] https://git.gnome.org/browse/jhbuild/

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,6 +1,15 @@
 #!/bin/sh
 
+set -e
+
 source env.sh
+
+# to allow bootstrapping again, try to delete everything first
+rm -Rf "_jhbuild"
+rm -Rf "_bundler"
+rm -Rf "$HOME/.local"
+rm -f "$HOME/.jhbuildrc"
+rm -f "$HOME/.jhbuildrc-custom"
 
 mkdir -p "$HOME"
 git clone git://git.gnome.org/jhbuild _jhbuild

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -17,7 +17,7 @@ JHBUILD_REVISION="7c8d34736c3804"
 mkdir -p "$HOME"
 git clone git://git.gnome.org/jhbuild _jhbuild
 (cd _jhbuild && git checkout "$JHBUILD_REVISION" && ./autogen.sh && make -f Makefile.plain DISABLE_GETTEXT=1 install >/dev/null)
-cp misc/gtk-osx-jhbuildrc "$HOME/.jhbuildrc"
-cp misc/jhbuildrc-custom "$HOME/.jhbuildrc-custom"
+ln misc/gtk-osx-jhbuildrc "$HOME/.jhbuildrc"
+ln misc/jhbuildrc-custom "$HOME/.jhbuildrc-custom"
 git clone git://git.gnome.org/gtk-mac-bundler _bundler
 (cd _bundler && make install)

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -11,9 +11,12 @@ rm -Rf "$HOME/.local"
 rm -f "$HOME/.jhbuildrc"
 rm -f "$HOME/.jhbuildrc-custom"
 
+# https://git.gnome.org/browse/gtk-osx/tree/jhbuild-revision
+JHBUILD_REVISION="7c8d34736c3804"
+
 mkdir -p "$HOME"
 git clone git://git.gnome.org/jhbuild _jhbuild
-(cd _jhbuild && ./autogen.sh && make -f Makefile.plain DISABLE_GETTEXT=1 install >/dev/null)
+(cd _jhbuild && git checkout "$JHBUILD_REVISION" && ./autogen.sh && make -f Makefile.plain DISABLE_GETTEXT=1 install >/dev/null)
 cp misc/gtk-osx-jhbuildrc "$HOME/.jhbuildrc"
 cp misc/jhbuildrc-custom "$HOME/.jhbuildrc-custom"
 git clone git://git.gnome.org/gtk-mac-bundler _bundler

--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
 
+set -e
+
 source env.sh
 
-jhbuild build autoconf --nodeps
 jhbuild bootstrap
 jhbuild build python
 jhbuild build meta-gtk-osx-bootstrap

--- a/bundle.sh
+++ b/bundle.sh
@@ -53,6 +53,7 @@ cp -R "$JHBUILD_PREFIX"/share/strings/*.lproj "$APP_PREFIX"
 # check for dynamic linking consistency : nothing should reference gtk/inst
 find "$APP_PREFIX" -name '*.so' -and -print -and  -exec sh -c 'otool -L $1 | grep /gtk/inst' '{}' '{}' ';'
 
+cat "$JHBUILD_PREFIX/_jhbuild/info/"* > "$JHBUILD_PREFIX/_jhbuild/packagedb.xml"
 # list the provenance of every file in the bundle
 $mydir/misc/provenance.pl "$JHBUILD_PREFIX" "$APP" > "$QL_OSXBUNDLE_BUNDLE_DEST"/gPodder.contents
 

--- a/bundle.sh
+++ b/bundle.sh
@@ -50,6 +50,10 @@ mv gpodder.ui.tmp "$APP_PREFIX"/share/gpodder/ui/gtk/gpodder.ui
 # localization of Quit and other menu items controlled by gtk-mac-integration
 cp -R "$JHBUILD_PREFIX"/share/strings/*.lproj "$APP_PREFIX"
 
+# fixes this error at startup:
+# gPodder.app/Contents/Resources/lib/python2.7/site-packages/gpodder/gtkui/draw.py:300: GtkWarning: Cannot open pixbuf loader module file 'gPodder.app/Contents/Resources/etc/gtk-2.0/gdk-pixbuf.loaders': No such file or directory
+"$JHBUILD_PREFIX/bin/gdk-pixbuf-query-loaders" > "$APP_PREFIX"/etc/gtk-2.0/gdk-pixbuf.loaders
+
 # check for dynamic linking consistency : nothing should reference gtk/inst
 find "$APP_PREFIX" -name '*.so' -and -print -and  -exec sh -c 'otool -L $1 | grep /gtk/inst' '{}' '{}' ';'
 

--- a/env.sh
+++ b/env.sh
@@ -7,6 +7,12 @@ cd "$DIR"
 # binaries available, e.g. from homebrew
 export PATH="/usr/bin:/bin:/usr/sbin:/sbin"
 
+# java is unnecessary for gpodder; but some packages check for its
+# presence at configuration step; on OSX, if java is not installed,
+# an annoying dialog appears => to avoid that, we alias java-related
+# commands to return an error exit code
+export PATH="$DIR/fake_java:$PATH"
+
 export HOME="$DIR/_home"
 export PATH="$PATH:$HOME/.local/bin:$HOME/jhbuild_prefix/bin"
 export QL_OSXBUNDLE_MODULESETS_DIR="$DIR/modulesets"

--- a/env.sh
+++ b/env.sh
@@ -3,6 +3,10 @@
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 cd "$DIR"
 
+# reset `$PATH` to defaults to make sure there are no non-standard
+# binaries available, e.g. from homebrew
+export PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+
 export HOME="$DIR/_home"
 export PATH="$PATH:$HOME/.local/bin:$HOME/jhbuild_prefix/bin"
 export QL_OSXBUNDLE_MODULESETS_DIR="$DIR/modulesets"

--- a/fake_java/java
+++ b/fake_java/java
@@ -1,0 +1,1 @@
+/usr/bin/false

--- a/fake_java/javac
+++ b/fake_java/javac
@@ -1,0 +1,1 @@
+/usr/bin/false

--- a/fake_java/javah
+++ b/fake_java/javah
@@ -1,0 +1,1 @@
+/usr/bin/false

--- a/fake_java/javap
+++ b/fake_java/javap
@@ -1,0 +1,1 @@
+/usr/bin/false

--- a/misc/gtk-osx-jhbuildrc
+++ b/misc/gtk-osx-jhbuildrc
@@ -368,10 +368,11 @@ def setup_sdk(target, sdk_version, architectures=[_default_arch]):
     # El Capitan needs bash to work around SIP. If you're using a
     # common bootstrap directory (e.g. $HOME/.local) then override
     # CONFIG_SHELL in .jhbuildrc-custom after calling setup_sdk().
+    config_shell = os.path.join(prefix, 'bin', 'bash')
     if _osx_version < 11.0:
         skip.append('bash')
-    elif not 'bootstrap' in modules:
-        os.environ['CONFIG_SHELL'] = os.path.join(prefix, 'bin', 'bash')
+    elif os.path.exists(config_shell):
+        os.environ['CONFIG_SHELL'] = config_shell
 
     # gettext-fw rebuilds gettext with an in-tree libiconv to get
     # around the Apple-provided one not defining _libiconv_init for
@@ -547,6 +548,7 @@ if os.path.exists(_userrc):
 # builds, for example.
 #
 _build = os.environ.get('JHB', _gtk_osx_default_build)
+disable_Werror = False
 
 ###### Everything Below Uses (and Overrides) customizations! #######
 

--- a/misc/jhbuildrc-custom
+++ b/misc/jhbuildrc-custom
@@ -6,7 +6,7 @@ import os
 checkoutroot = os.path.expanduser("~/jhbuild_checkoutroot")
 prefix = os.path.expanduser("~/jhbuild_prefix")
 modulesets_dir = os.environ["QL_OSXBUNDLE_MODULESETS_DIR"]
-moduleset = ["bootstrap", "quodlibet"]
+moduleset = "gpodder"
 modules = []
 
 disable_Werror = False

--- a/misc/provenance.pl
+++ b/misc/provenance.pl
@@ -38,7 +38,7 @@ foreach my $pkg (@manifest_files) {
 	open(my $MANIFEST, "<", $manifest) || die "can't open $manifest for reading: $!\n";
 	while(my $l = <$MANIFEST>){
 		chomp $l;
-		push(@{$pkg_by_f{$l}}, $pkg);
+		push(@{$pkg_by_f{"/$l"}}, $pkg);
 	}
 }
 
@@ -52,10 +52,9 @@ foreach my $file (@files) {
 	next if -d $file;
 	my $short = $file;
 	$short =~ s/$gPodderResources//;
-	my $inst = "$gtk_inst$short";
 	my @pkgs;
-	if($pkg_by_f{$inst}){
-		@pkgs = @{$pkg_by_f{$inst}};
+	if($pkg_by_f{$short}){
+		@pkgs = @{$pkg_by_f{$short}};
 	} else {
 		@pkgs = ();
 	}

--- a/modulesets/bootstrap.modules
+++ b/modulesets/bootstrap.modules
@@ -21,11 +21,17 @@
   <repository type="tarball" name="intltool"
               href="http://launchpad.net/intltool/trunk/"/>
 
-  <autotools id="make">
+  <autotools id="make" bootstrap="true">
     <branch repo="ftp.gnu.org" module="make/make-3.82.tar.gz" version="3.82"/>
   </autotools>
 
-  <autotools id='bash' autogen-sh="configure">
+  <autotools id='readline' autogen-sh="configure">
+    <branch repo="ftp.gnu.org" module="readline/readline-6.3.tar.gz"
+      version="6.3">
+    </branch>
+  </autotools>
+
+  <autotools id='bash' autogen-sh="configure"  autogenargs="--with-installed-readline">
     <branch repo="ftp.gnu.org" module="bash/bash-4.3.30.tar.gz"
             version="4.3.30"/>
     <dependencies>
@@ -33,7 +39,7 @@
     </dependencies>
   </autotools>
 
-  <autotools id="xz" autogen-sh="configure">
+  <autotools id="xz" autogen-sh="configure" bootstrap="true">
     <branch repo="tukaani.org" module="xz/xz-5.2.1.tar.bz2" version="5.2.1"/>
   </autotools>
 
@@ -67,57 +73,76 @@
   <autotools id="cmake" autogen-sh="bootstrap"
              autogen-template="%(srcdir)s/%(autogen-sh)s --prefix=%(prefix)s">
     <branch repo="cmake" module="v3.2/cmake-3.2.1.tar.gz" version="3.2.1">
-      <patch file="http://git.gnome.org/browse/gtk-osx/plain/patches/cmake-libnetwork.patch" strip="1"/>
+      <patch file="https://git.gnome.org/browse/gtk-osx/plain/patches/cmake-libnetwork.patch" strip="1"/>
     </branch>
   </autotools>
 
-  <autotools id="m4" autogen-sh="configure">
+  <autotools id="m4" autogen-sh="configure" bootstrap="true">
     <branch repo="ftp.gnu.org"
             module="m4/m4-1.4.17.tar.xz" version="1.4.17"/>
   </autotools>
 
-  <autotools id="autoconf" autogen-sh="configure">
+  <autotools id="autoconf" autogen-sh="configure" bootstrap="true">
     <branch repo="ftp.gnu.org"
             module="autoconf/autoconf-2.69.tar.xz" version="2.69"/>
     <dependencies>
+      <dep package="xz"/>
       <dep package="m4"/>
     </dependencies>
   </autotools>
 
-  <autotools id="libtool" autogen-sh="configure">
+  <autotools id="libtool" autogen-sh="configure" bootstrap="true">
     <branch repo="ftp.gnu.org"
             module="libtool/libtool-2.4.6.tar.gz" version="2.4.6"/>
   </autotools>
 
-  <autotools id="automake-1.10" autogen-sh="configure">
+  <autotools id="automake-1.10" autogen-sh="configure" bootstrap="true">
     <branch repo="ftp.gnu.org"
             module="automake/automake-1.10.3.tar.bz2" version="1.10.3"
             size="957505" md5sum="b8e67fb458da396bc35555af7ef2b49f" />
+    <dependencies>
+      <dep package="autoconf"/>
+    </dependencies>
   </autotools>
 
-  <autotools id="automake-1.11" autogen-sh="configure">
+  <autotools id="automake-1.11" autogen-sh="configure" bootstrap="true">
     <branch repo="ftp.gnu.org"
             module="automake/automake-1.11.6.tar.xz" version="1.11.6"/>
+    <dependencies>
+      <dep package="autoconf"/>
+    </dependencies>
   </autotools>
 
-  <autotools id="automake-1.12" autogen-sh="configure">
+  <autotools id="automake-1.12" autogen-sh="configure" bootstrap="true">
     <branch repo="ftp.gnu.org"
             module="automake/automake-1.12.6.tar.xz" version="1.12.6"/>
+    <dependencies>
+      <dep package="autoconf"/>
+    </dependencies>
   </autotools>
 
-  <autotools id="automake-1.13" autogen-sh="configure">
+  <autotools id="automake-1.13" autogen-sh="configure" bootstrap="true">
     <branch repo="ftp.gnu.org"
             module="automake/automake-1.13.4.tar.xz" version="1.13.4"/>
+    <dependencies>
+      <dep package="autoconf"/>
+    </dependencies>
   </autotools>
 
-  <autotools id="automake-1.14" autogen-sh="configure">
+  <autotools id="automake-1.14" autogen-sh="configure" bootstrap="true">
     <branch repo="ftp.gnu.org" version="1.14.1"
             module="automake/automake-1.14.1.tar.xz"/>
+    <dependencies>
+      <dep package="autoconf"/>
+    </dependencies>
   </autotools>
 
-  <autotools id="automake" autogen-sh="configure">
+  <autotools id="automake" autogen-sh="configure" bootstrap="true">
     <branch repo="ftp.gnu.org" version="1.15"
             module="automake/automake-1.15.tar.gz"/>
+    <dependencies>
+      <dep package="autoconf"/>
+    </dependencies>
   </autotools>
 
   <autotools id="pkg-config" autogen-sh="configure"
@@ -202,6 +227,7 @@
       <dep package="make"/>     <!-- Needed for Tiger, skipped otherwise -->
       <dep package="subversion"/>   <!-- Needed for Tiger, skipped otherwise -->
       <dep package="gettext-tools" /> <!-- Needed for 64-bit -->
+      <dep package="readline" />
       <dep package="bash" />  <!-- Needed for El Cap and later to work around SIP. -->
       <dep package="cmake"/>
       <dep package="m4"/>	<!-- Can be skipped for Leopard and later -->

--- a/modulesets/gtk-osx-network.modules
+++ b/modulesets/gtk-osx-network.modules
@@ -45,7 +45,9 @@
   <autotools id="openssl" autogen-sh="Configure" autogenargs="shared"
              autogen-template="%(srcdir)s/%(autogen-sh)s --prefix=%(prefix)s --openssldir=%(prefix)s/etc/ssl %(autogenargs)s"
              makeinstallargs="install_sw" supports-non-srcdir-builds="no" supports-parallel-builds="no">
-    <branch module="openssl-0.9.8zg.tar.gz" version="0.9.8zg" repo="openssl"/>
+    <branch module="openssl-0.9.8zg.tar.gz" version="0.9.8zg" repo="openssl">
+      <patch file="patches/openssl-respect-destdir.patch" />
+    </branch>
   </autotools>
 
   <!-- Rudely demands TeX to build documentation -->

--- a/modulesets/gtk-osx-python.modules
+++ b/modulesets/gtk-osx-python.modules
@@ -72,7 +72,9 @@
 	     autogen-sh="configure" supports-non-srcdir-builds="no">
     <branch repo="python"
 	    module="2.7.8/Python-2.7.8.tar.xz" version="2.7.8">
-      <patch file="http://git.gnome.org/browse/gtk-osx/plain/patches/python-2.7.8-test_grammar.py-typo.patch" strip="1"/>
+      <patch file="https://git.gnome.org/browse/gtk-osx/plain/patches/python2-test_grammar.py-typo.patch" strip="1"/>
+      <patch file="https://git.gnome.org/browse/gtk-osx/plain/patches/python2-xcode-stubs.patch" strip="1"/>
+      <patch file="https://git.gnome.org/browse/gtk-osx/plain/patches/python2-linkflags.patch" strip="1"/>"/>
     </branch>
     <dependencies>
       <dep package="gettext-runtime"/>

--- a/modulesets/gtk-osx.modules
+++ b/modulesets/gtk-osx.modules
@@ -183,7 +183,7 @@
             hash="sha256:b2c6441e98bc5232e5f9bba6965075dcf580a8726398f7374d39f90b88ed4656">
       <!--patch file="http://git.gnome.org/browse/gtk-osx/plain/patches/0004-Bug-571582-GtkSelection-implementation-for-quartz.patch" strip="1"/-->
       <patch file="http://git.gnome.org/browse/gtk-osx/plain/patches/0008-Implement-GtkDragSourceOwner-pasteboardChangedOwner.patch" strip="1"/>
-      <patch file="http://git.gnome.org/browse/gtk-osx/plain/patches/0006-Bug-658722-Drag-and-Drop-sometimes-stops-working.patch" strip="1"/>
+      <patch file="https://git.gnome.org/browse/gtk-osx/plain/patches/0006-Bug-658722-Drag-and-Drop-sometimes-stops-working.patch?id=6c455cb011c29784c82335031deea78cf7aec52b" strip="1"/>
 <patch file="http://git.gnome.org/browse/gtk-osx/plain/patches/gtk+-2-m4-creation.patch" strip="1"/>
       <patch file="http://git.gnome.org/browse/gtk-osx/plain/patches/0001-Bug-707945-GTK2-Quartz-typeahead-find-in-GtkTreeView.patch" strip="1"/>
    </branch>

--- a/modulesets/patches/openssl-respect-destdir.patch
+++ b/modulesets/patches/openssl-respect-destdir.patch
@@ -1,0 +1,11 @@
+--- Configure	2016-04-27 22:53:25.000000000 -0700
++++ Configure	2016-04-27 22:53:47.000000000 -0700
+@@ -595,7 +595,7 @@
+ my $libdir="";
+ my $openssldir="";
+ my $exe_ext="";
+-my $install_prefix= "$ENV{'INSTALL_PREFIX'}";
++my $install_prefix='$(DESTDIR)';
+ my $cross_compile_prefix="";
+ my $fipslibdir="/usr/local/ssl/fips-1.0/lib/";
+ my $nofipscanistercheck=0;


### PR DESCRIPTION
Continuation for PR #4, should be merged after that one. Contains a few enhancements to the scripts:

* Change README to asciidoc format, so that it's rendered more nicely by github.
* `bootstrap.sh`: allow bootstrapping again (copied from quodlibet's scripts: https://github.com/quodlibet/quodlibet/blob/master/osx_bundle/bootstrap.sh).
* `bootstrap.sh`: checkout specific `jhbuild` commit. This makes sure we're using a stable version. Based on the official `jhbuild` setup script: https://git.gnome.org/browse/gtk-osx/plain/gtk-osx-build-setup.sh
* `env.sh`: reset `$PATH` to defaults. This ensures only system binaries are used in the build process.
* `env.sh`: short-circuit java binaries to `false`. This avoids an annoying dialog on OSX in case java is not installed in the system (which is the default).
* `bootstrap.sh`: link `jhbuildrc` files instead of copying. IMHO, in most cases, if you modify the files in the custom `$HOME` location, you want the changes to be reflected in the repository for easier tracking and committing.